### PR TITLE
단 건 게시글 생성 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/hanghae/board/application/PostController.java
+++ b/src/main/java/com/hanghae/board/application/PostController.java
@@ -1,10 +1,15 @@
 package com.hanghae.board.application;
 
+import com.hanghae.board.domain.post.dto.PostCommand;
+import com.hanghae.board.domain.post.dto.PostDto;
 import com.hanghae.board.domain.post.entity.Post;
 import com.hanghae.board.domain.post.service.PostReadService;
+import com.hanghae.board.domain.post.service.PostWriteService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,9 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
   private final PostReadService postReadService;
+  private final PostWriteService postWriteService;
 
   @GetMapping
   public List<Post> getPosts() {
     return postReadService.getPosts();
+  }
+
+  @PostMapping
+  public PostDto create(@RequestBody PostCommand command) {
+    return postWriteService.create(command);
   }
 }

--- a/src/main/java/com/hanghae/board/application/PostController.java
+++ b/src/main/java/com/hanghae/board/application/PostController.java
@@ -2,7 +2,6 @@ package com.hanghae.board.application;
 
 import com.hanghae.board.domain.post.dto.PostCommand;
 import com.hanghae.board.domain.post.dto.PostDto;
-import com.hanghae.board.domain.post.entity.Post;
 import com.hanghae.board.domain.post.service.PostReadService;
 import com.hanghae.board.domain.post.service.PostWriteService;
 import java.util.List;
@@ -22,7 +21,7 @@ public class PostController {
   private final PostWriteService postWriteService;
 
   @GetMapping
-  public List<Post> getPosts() {
+  public List<PostDto> getPosts() {
     return postReadService.getPosts();
   }
 

--- a/src/main/java/com/hanghae/board/application/PostController.java
+++ b/src/main/java/com/hanghae/board/application/PostController.java
@@ -27,6 +27,6 @@ public class PostController {
 
   @PostMapping
   public PostDto create(@RequestBody PostCommand command) {
-    return postWriteService.create(command);
+    return postWriteService.createPost(command);
   }
 }

--- a/src/main/java/com/hanghae/board/config/SecurityConfig.java
+++ b/src/main/java/com/hanghae/board/config/SecurityConfig.java
@@ -16,13 +16,16 @@ public class SecurityConfig {
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http
-        .authorizeHttpRequests(authz -> authz
-                // TODO: 회원 구현 후 수정
-                .requestMatchers("*").permitAll()
-//            .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+        .authorizeHttpRequests(authz ->
+            authz
+                // NOTE: Swagger UI 관련 요청은 인증 없이 허용 (개발 중에만 사용, 프로덕션에서는 제거해야 함)
+                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html")
+                .permitAll()
+                // NOTE: 임시로 모든 요청 허용 (개발 중에만 사용, 프로덕션에서는 제거해야 함)
+                .requestMatchers("/**").permitAll()
                 .anyRequest().authenticated()
         )
-        .csrf(AbstractHttpConfigurer::disable);  // CSRF 비활성화를 위한 새로운 방법
+        .csrf(AbstractHttpConfigurer::disable);  // NOTE: CSRF 비활성화
 
     return http.build();
   }

--- a/src/main/java/com/hanghae/board/config/SecurityConfig.java
+++ b/src/main/java/com/hanghae/board/config/SecurityConfig.java
@@ -1,0 +1,34 @@
+package com.hanghae.board.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        .authorizeHttpRequests(authz -> authz
+                // TODO: 회원 구현 후 수정
+                .requestMatchers("*").permitAll()
+//            .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .anyRequest().authenticated()
+        )
+        .csrf(AbstractHttpConfigurer::disable);  // CSRF 비활성화를 위한 새로운 방법
+
+    return http.build();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+}

--- a/src/main/java/com/hanghae/board/domain/post/dto/PostCommand.java
+++ b/src/main/java/com/hanghae/board/domain/post/dto/PostCommand.java
@@ -1,0 +1,10 @@
+package com.hanghae.board.domain.post.dto;
+
+public record PostCommand(
+    String title,
+    String content,
+    String username,
+    String password
+) {
+
+}

--- a/src/main/java/com/hanghae/board/domain/post/dto/PostDto.java
+++ b/src/main/java/com/hanghae/board/domain/post/dto/PostDto.java
@@ -7,7 +7,6 @@ public record PostDto(
     String title,
     String content,
     String username,
-    String password,
     LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/hanghae/board/domain/post/dto/PostDto.java
+++ b/src/main/java/com/hanghae/board/domain/post/dto/PostDto.java
@@ -6,6 +6,8 @@ public record PostDto(
     Long id,
     String title,
     String content,
+    String username,
+    String password,
     LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/hanghae/board/domain/post/entity/Post.java
+++ b/src/main/java/com/hanghae/board/domain/post/entity/Post.java
@@ -33,6 +33,9 @@ public class Post {
   @Column(nullable = false, length = 50)
   private String username;
 
+  @Column(nullable = false, length = 256)
+  private String password;
+
   @Column(name = "created_at", nullable = false, updatable = false)
   private LocalDateTime createdAt;
 
@@ -40,11 +43,13 @@ public class Post {
   private LocalDateTime updatedAt;
 
   @Builder
-  private Post(String title, String content, String username, LocalDateTime createdAt,
+  private Post(String title, String content, String username, String password,
+      LocalDateTime createdAt,
       LocalDateTime updatedAt) {
     this.title = Objects.requireNonNull(title);
     this.content = Objects.requireNonNull(content);
     this.username = Objects.requireNonNull(username);
+    this.password = Objects.requireNonNull(password);
     this.createdAt = createdAt == null ? LocalDateTime.now() : createdAt;
     this.updatedAt = updatedAt;
   }

--- a/src/main/java/com/hanghae/board/domain/post/mapper/PostMapper.java
+++ b/src/main/java/com/hanghae/board/domain/post/mapper/PostMapper.java
@@ -13,7 +13,6 @@ public class PostMapper {
         post.getTitle(),
         post.getContent(),
         post.getUsername(),
-        post.getPassword(),
         post.getCreatedAt(),
         post.getUpdatedAt()
     );

--- a/src/main/java/com/hanghae/board/domain/post/mapper/PostMapper.java
+++ b/src/main/java/com/hanghae/board/domain/post/mapper/PostMapper.java
@@ -1,0 +1,21 @@
+package com.hanghae.board.domain.post.mapper;
+
+import com.hanghae.board.domain.post.dto.PostDto;
+import com.hanghae.board.domain.post.entity.Post;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostMapper {
+
+  public PostDto toDto(Post post) {
+    return new PostDto(
+        post.getId(),
+        post.getTitle(),
+        post.getContent(),
+        post.getUsername(),
+        post.getPassword(),
+        post.getCreatedAt(),
+        post.getUpdatedAt()
+    );
+  }
+}

--- a/src/main/java/com/hanghae/board/domain/post/service/PostReadService.java
+++ b/src/main/java/com/hanghae/board/domain/post/service/PostReadService.java
@@ -1,7 +1,8 @@
 package com.hanghae.board.domain.post.service;
 
 
-import com.hanghae.board.domain.post.entity.Post;
+import com.hanghae.board.domain.post.dto.PostDto;
+import com.hanghae.board.domain.post.mapper.PostMapper;
 import com.hanghae.board.domain.post.repository.PostRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +13,11 @@ import org.springframework.stereotype.Service;
 public class PostReadService {
 
   private final PostRepository postRepository;
+  private final PostMapper postMapper;
 
-  public List<Post> getPosts() {
-    return postRepository.findAllByOrderByCreatedAtDesc();
+  public List<PostDto> getPosts() {
+    return postRepository.findAllByOrderByCreatedAtDesc().stream()
+        .map(postMapper::toDto)
+        .toList();
   }
 }

--- a/src/main/java/com/hanghae/board/domain/post/service/PostWriteService.java
+++ b/src/main/java/com/hanghae/board/domain/post/service/PostWriteService.java
@@ -1,0 +1,34 @@
+package com.hanghae.board.domain.post.service;
+
+
+import com.hanghae.board.domain.post.dto.PostCommand;
+import com.hanghae.board.domain.post.dto.PostDto;
+import com.hanghae.board.domain.post.entity.Post;
+import com.hanghae.board.domain.post.mapper.PostMapper;
+import com.hanghae.board.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class PostWriteService {
+
+  private final PostRepository postRepository;
+  private final PostMapper postMapper;
+  private final PasswordEncoder passwordEncoder;
+
+  public PostDto create(PostCommand postCommand) {
+
+    var post = Post
+        .builder()
+        .title(postCommand.title())
+        .content(postCommand.content())
+        .username(postCommand.username())
+        .password(passwordEncoder.encode(postCommand.password()))
+        .build();
+
+    return postMapper.toDto(postRepository.save(post));
+  }
+
+}

--- a/src/main/java/com/hanghae/board/domain/post/service/PostWriteService.java
+++ b/src/main/java/com/hanghae/board/domain/post/service/PostWriteService.java
@@ -18,7 +18,7 @@ public class PostWriteService {
   private final PostMapper postMapper;
   private final PasswordEncoder passwordEncoder;
 
-  public PostDto create(PostCommand postCommand) {
+  public PostDto createPost(PostCommand postCommand) {
 
     var post = Post
         .builder()

--- a/src/test/java/com/hanghae/board/domain/post/PostReadServiceTest.java
+++ b/src/test/java/com/hanghae/board/domain/post/PostReadServiceTest.java
@@ -44,14 +44,13 @@ class PostReadServiceTest {
 
   @Test
   void 모든_게시글을_생성일_기준_내림차순으로_조회한다() {
-    List<Post> 게시글목록 = postReadService.getPosts();
+    var 게시글목록 = postReadService.getPosts();
 
     assertNotNull(게시글목록);
     assertEquals(testPosts.size(), 게시글목록.size());
 
     for (int i = 0; i < 게시글목록.size() - 1; i++) {
-      System.out.println(게시글목록.get(i).getCreatedAt());
-      assertTrue(게시글목록.get(i).getCreatedAt().isAfter(게시글목록.get(i + 1).getCreatedAt()));
+      assertTrue(게시글목록.get(i).createdAt().isAfter(게시글목록.get(i + 1).createdAt()));
     }
   }
 }

--- a/src/test/java/com/hanghae/board/domain/post/PostWriteServiceTest.java
+++ b/src/test/java/com/hanghae/board/domain/post/PostWriteServiceTest.java
@@ -1,0 +1,39 @@
+package com.hanghae.board.domain.post;
+
+import com.hanghae.board.domain.post.dto.PostCommand;
+import com.hanghae.board.domain.post.service.PostWriteService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@SpringBootTest
+class PostWriteServiceTest {
+
+  @Autowired
+  private PostWriteService postWriteService;
+
+  @Autowired
+  private PasswordEncoder passwordEncoder;
+
+  @Test
+  void 게시물_단건_생성() {
+    PostCommand postCommand = new PostCommand(
+        "제목",
+        "내용",
+        "작성자",
+        "비밀번호"
+    );
+
+    var post = postWriteService.create(postCommand);
+
+    Assertions.assertThat(post.id()).isNotNull();
+    Assertions.assertThat(post.title()).isEqualTo(postCommand.title());
+    Assertions.assertThat(post.content()).isEqualTo(postCommand.content());
+    Assertions.assertThat(post.username()).isEqualTo(postCommand.username());
+    Assertions.assertThat(passwordEncoder.matches(postCommand.password(), post.password()))
+        .isTrue();
+
+  }
+}

--- a/src/test/java/com/hanghae/board/domain/post/PostWriteServiceTest.java
+++ b/src/test/java/com/hanghae/board/domain/post/PostWriteServiceTest.java
@@ -26,7 +26,7 @@ class PostWriteServiceTest {
         "비밀번호"
     );
 
-    var post = postWriteService.create(postCommand);
+    var post = postWriteService.createPost(postCommand);
 
     Assertions.assertThat(post.id()).isNotNull();
     Assertions.assertThat(post.title()).isEqualTo(postCommand.title());

--- a/src/test/java/com/hanghae/board/domain/post/PostWriteServiceTest.java
+++ b/src/test/java/com/hanghae/board/domain/post/PostWriteServiceTest.java
@@ -32,8 +32,5 @@ class PostWriteServiceTest {
     Assertions.assertThat(post.title()).isEqualTo(postCommand.title());
     Assertions.assertThat(post.content()).isEqualTo(postCommand.content());
     Assertions.assertThat(post.username()).isEqualTo(postCommand.username());
-    Assertions.assertThat(passwordEncoder.matches(postCommand.password(), post.password()))
-        .isTrue();
-
   }
 }


### PR DESCRIPTION
단 건 게시글을 생성하는 API를 구현하였습니다.

요구 사항
- 제목, 작성자명, 비밀번호, 작성 내용을 저장하고
- 저장된 게시글을 Client 로 반환하기

적용 사항
- Post password 컬럼 추가
- Spring Security 추가 (PasswordEncoder 사용)
- 단건 게시물 생성 API 구현
- 단건 게시물 생성 테스트 코드

추가로
PasswordEncoder을 사용을 위해 Spring Security를 설치했습니다. (추후 회원 기능 추가 예정)
지금은 회원기능이 없습니다. 그러므로 임시로 권한 체크를 따로 안하도록 설정했습니다.