### PR TITLE
추가 요구사항 반영 (2차)

### DIFF
--- a/src/main/java/com/hanghae/board/application/controller/AuthController.java
+++ b/src/main/java/com/hanghae/board/application/controller/AuthController.java
@@ -34,7 +34,7 @@ public class AuthController {
   }
 
   @PostMapping("/login")
-  public ResponseEntity<Boolean> authenticateUser(@RequestBody LoginDto loginDto,
+  public ResponseEntity<Boolean> authenticateUser(@RequestBody @Valid LoginDto loginDto,
       HttpServletResponse response) {
     Authentication authentication = authenticationManager.authenticate(
         new UsernamePasswordAuthenticationToken(loginDto.getUsername(), loginDto.getPassword())

--- a/src/main/java/com/hanghae/board/application/controller/CommentController.java
+++ b/src/main/java/com/hanghae/board/application/controller/CommentController.java
@@ -1,8 +1,10 @@
 package com.hanghae.board.application.controller;
 
 import com.hanghae.board.application.usecase.AddCommentUseCase;
+import com.hanghae.board.application.usecase.UpdateCommentUseCase;
 import com.hanghae.board.domain.comment.dto.CommentCommand;
 import com.hanghae.board.domain.comment.dto.CommentDetailDto;
+import com.hanghae.board.domain.comment.dto.UpdateCommentCommand;
 import com.hanghae.board.security.CurrentUser;
 import com.hanghae.board.security.UserPrincipal;
 import jakarta.validation.Valid;
@@ -12,16 +14,19 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/posts/{postId}/comments")
+@RequestMapping("/posts/{postId:\\d+}/comments")
 @RequiredArgsConstructor
 public class CommentController {
 
   private final AddCommentUseCase addCommentUseCase;
+
+  private final UpdateCommentUseCase updateCommentUseCase;
 
   @PostMapping
   @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
@@ -32,6 +37,18 @@ public class CommentController {
     var comment = addCommentUseCase.execute(postId, command, currentUser);
 
     return ResponseEntity.status(HttpStatus.CREATED).body(comment);
+  }
+
+  @PutMapping("/{commentId:\\d+}")
+  @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+  public ResponseEntity<CommentDetailDto> updateComment(
+      @PathVariable Long postId, @PathVariable Long commentId,
+      @RequestBody @Valid UpdateCommentCommand command,
+      @CurrentUser UserPrincipal currentUser) {
+
+    var comment = updateCommentUseCase.execute(postId, commentId, command, currentUser);
+
+    return ResponseEntity.ok(comment);
   }
 
 }

--- a/src/main/java/com/hanghae/board/application/controller/CommentController.java
+++ b/src/main/java/com/hanghae/board/application/controller/CommentController.java
@@ -1,0 +1,38 @@
+package com.hanghae.board.application.controller;
+
+import com.hanghae.board.application.usecase.AddCommentUseCase;
+import com.hanghae.board.domain.comment.dto.CommentCommand;
+import com.hanghae.board.domain.comment.dto.CommentDetailDto;
+import com.hanghae.board.security.CurrentUser;
+import com.hanghae.board.security.UserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/posts/{postId}/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+  private final AddCommentUseCase addCommentUseCase;
+
+  @PostMapping
+  @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+  public ResponseEntity<CommentDetailDto> createComment(
+      @PathVariable Long postId, @RequestBody @Valid CommentCommand command,
+      @CurrentUser UserPrincipal currentUser) {
+
+    var comment = addCommentUseCase.execute(postId, command, currentUser);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(comment);
+  }
+
+}
+

--- a/src/main/java/com/hanghae/board/application/controller/PostController.java
+++ b/src/main/java/com/hanghae/board/application/controller/PostController.java
@@ -57,7 +57,7 @@ public class PostController {
   @PutMapping("/{id:\\d+}")
   @PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
   public ResponseEntity<PostDto> update(@PathVariable Long id,
-      @RequestBody UpdatePostCommand command, @CurrentUser UserPrincipal currentUser) {
+      @RequestBody @Valid UpdatePostCommand command, @CurrentUser UserPrincipal currentUser) {
     PostDto post = postWriteService.updatePost(id, command, currentUser);
 
     return ResponseEntity.status(HttpStatus.OK).body(post);

--- a/src/main/java/com/hanghae/board/application/usecase/AddCommentUseCase.java
+++ b/src/main/java/com/hanghae/board/application/usecase/AddCommentUseCase.java
@@ -1,0 +1,34 @@
+package com.hanghae.board.application.usecase;
+
+import com.hanghae.board.domain.comment.dto.CommentCommand;
+import com.hanghae.board.domain.comment.dto.CommentDetailDto;
+import com.hanghae.board.domain.comment.mapper.CommentMapper;
+import com.hanghae.board.domain.comment.service.CommentWriteService;
+import com.hanghae.board.domain.post.service.PostReadService;
+import com.hanghae.board.domain.user.service.UserReadService;
+import com.hanghae.board.security.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AddCommentUseCase {
+
+  private final CommentWriteService commentWriteService;
+
+  private final PostReadService postReadService;
+
+  private final UserReadService userReadService;
+
+  private final CommentMapper commentMapper;
+
+
+  public CommentDetailDto execute(Long postId, CommentCommand command, UserPrincipal currentUser) {
+    var post = postReadService.getPost(postId);
+    var user = userReadService.getUser(post.getUserId());
+
+    var comment = commentWriteService.createComment(post.getId(), command, currentUser);
+
+    return commentMapper.toCommentDetailDto(comment, user);
+  }
+}

--- a/src/main/java/com/hanghae/board/application/usecase/UpdateCommentUseCase.java
+++ b/src/main/java/com/hanghae/board/application/usecase/UpdateCommentUseCase.java
@@ -1,0 +1,35 @@
+package com.hanghae.board.application.usecase;
+
+import com.hanghae.board.domain.comment.dto.CommentDetailDto;
+import com.hanghae.board.domain.comment.dto.UpdateCommentCommand;
+import com.hanghae.board.domain.comment.mapper.CommentMapper;
+import com.hanghae.board.domain.comment.service.CommentWriteService;
+import com.hanghae.board.domain.post.service.PostReadService;
+import com.hanghae.board.domain.user.service.UserReadService;
+import com.hanghae.board.security.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateCommentUseCase {
+
+  private final CommentWriteService commentWriteService;
+
+  private final PostReadService postReadService;
+
+  private final UserReadService userReadService;
+
+  private final CommentMapper commentMapper;
+
+  public CommentDetailDto execute(Long postId, Long commentId, UpdateCommentCommand command,
+      UserPrincipal currentUser) {
+    var post = postReadService.getPost(postId);
+    var user = userReadService.getUser(post.getUserId());
+
+    var comment = commentWriteService.updateComment(commentId, command, currentUser);
+
+    return commentMapper.toCommentDetailDto(comment, user);
+  }
+
+}

--- a/src/main/java/com/hanghae/board/config/SecurityConfig.java
+++ b/src/main/java/com/hanghae/board/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.hanghae.board.config;
 
+import com.hanghae.board.security.UserDetailsServiceImpl;
 import com.hanghae.board.security.jwt.JwtAuthenticationFilter;
 import com.hanghae.board.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
   private final JwtTokenProvider jwtTokenProvider;
+
+  private final UserDetailsServiceImpl customUserDetailsService;
+
 
   @Bean
   public PasswordEncoder passwordEncoder() {
@@ -60,7 +64,7 @@ public class SecurityConfig {
             .anyRequest().authenticated());
 
     http
-        .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+        .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, customUserDetailsService),
             UsernamePasswordAuthenticationFilter.class);
 
     // NOTE: 세션 비활성화

--- a/src/main/java/com/hanghae/board/domain/comment/dto/CommentCommand.java
+++ b/src/main/java/com/hanghae/board/domain/comment/dto/CommentCommand.java
@@ -1,0 +1,18 @@
+package com.hanghae.board.domain.comment.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
+public class CommentCommand {
+
+  @NotEmpty
+  private final String content;
+
+}

--- a/src/main/java/com/hanghae/board/domain/comment/dto/CommentDetailDto.java
+++ b/src/main/java/com/hanghae/board/domain/comment/dto/CommentDetailDto.java
@@ -1,0 +1,37 @@
+package com.hanghae.board.domain.comment.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
+public class CommentDetailDto {
+
+  @NotNull
+  private final Long id;
+
+  @NotEmpty
+  private final String content;
+
+  @NotNull
+  private final Long postId;
+
+  @NotNull
+  private final Long userId;
+
+  @NotNull
+  private final LocalDateTime createdAt;
+
+  @NotNull
+  private final LocalDateTime updatedAt;
+
+  @NotNull
+  private final UserDto user;
+}

--- a/src/main/java/com/hanghae/board/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/hanghae/board/domain/comment/dto/CommentDto.java
@@ -1,0 +1,33 @@
+package com.hanghae.board.domain.comment.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
+public class CommentDto {
+
+  @NotNull
+  private final Long id;
+
+  @NotEmpty
+  private final String content;
+
+  @NotNull
+  private final Long postId;
+
+  @NotNull
+  private final Long userId;
+
+  @NotNull
+  private final LocalDateTime createdAt;
+
+  private final LocalDateTime updatedAt;
+}

--- a/src/main/java/com/hanghae/board/domain/comment/dto/UpdateCommentCommand.java
+++ b/src/main/java/com/hanghae/board/domain/comment/dto/UpdateCommentCommand.java
@@ -1,0 +1,18 @@
+package com.hanghae.board.domain.comment.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
+public class UpdateCommentCommand {
+
+  @NotEmpty
+  private final String content;
+
+}

--- a/src/main/java/com/hanghae/board/domain/comment/entity/Comment.java
+++ b/src/main/java/com/hanghae/board/domain/comment/entity/Comment.java
@@ -1,0 +1,58 @@
+package com.hanghae.board.domain.comment.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "comments")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Comment {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @NotEmpty
+  private String content;
+
+  @NotNull
+  @Positive
+  private Long postId;
+
+  @NotNull
+  @Positive
+  private Long userId;
+
+  @NotNull
+  @PastOrPresent
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(insertable = false)
+  private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/hanghae/board/domain/comment/entity/Comment.java
+++ b/src/main/java/com/hanghae/board/domain/comment/entity/Comment.java
@@ -55,4 +55,7 @@ public class Comment {
   @Column(insertable = false)
   private LocalDateTime updatedAt;
 
+  public void update(String content) {
+    this.content = content;
+  }
 }

--- a/src/main/java/com/hanghae/board/domain/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/hanghae/board/domain/comment/exception/CommentErrorCode.java
@@ -1,24 +1,33 @@
 package com.hanghae.board.domain.comment.exception;
 
 import com.hanghae.board.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+@Getter
+@RequiredArgsConstructor
 public enum CommentErrorCode implements ErrorCode {
 
+  COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+  COMMENT_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "댓글 수정 권한이 없습니다."),
   ;
+
+  private final HttpStatus status;
+  private final String message;
 
   @Override
   public String getCode() {
-    return this.name();
+    return name();
   }
 
   @Override
   public HttpStatus getStatus() {
-    return this.getStatus();
+    return status;
   }
 
   @Override
   public String getMessage() {
-    return this.getMessage();
+    return message;
   }
 }

--- a/src/main/java/com/hanghae/board/domain/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/hanghae/board/domain/comment/exception/CommentErrorCode.java
@@ -1,0 +1,24 @@
+package com.hanghae.board.domain.comment.exception;
+
+import com.hanghae.board.error.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum CommentErrorCode implements ErrorCode {
+
+  ;
+
+  @Override
+  public String getCode() {
+    return this.name();
+  }
+
+  @Override
+  public HttpStatus getStatus() {
+    return this.getStatus();
+  }
+
+  @Override
+  public String getMessage() {
+    return this.getMessage();
+  }
+}

--- a/src/main/java/com/hanghae/board/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/hanghae/board/domain/comment/mapper/CommentMapper.java
@@ -1,0 +1,18 @@
+package com.hanghae.board.domain.comment.mapper;
+
+import com.hanghae.board.domain.comment.dto.CommentDetailDto;
+import com.hanghae.board.domain.comment.dto.CommentDto;
+import com.hanghae.board.domain.comment.dto.UserDto;
+import com.hanghae.board.domain.comment.entity.Comment;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface CommentMapper {
+
+  CommentDto toDto(Comment comment);
+
+  @Mapping(source = "comment.id", target = "id")
+  @Mapping(source = "userDto", target = "user")
+  CommentDetailDto toCommentDetailDto(CommentDto comment, UserDto userDto);
+}

--- a/src/main/java/com/hanghae/board/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hanghae/board/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.hanghae.board.domain.comment.repository;
+
+import com.hanghae.board.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/hanghae/board/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/hanghae/board/domain/comment/repository/CommentRepository.java
@@ -1,8 +1,13 @@
 package com.hanghae.board.domain.comment.repository;
 
 import com.hanghae.board.domain.comment.entity.Comment;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  Optional<Comment> findWithPessimisticLockById(Long id);
 }

--- a/src/main/java/com/hanghae/board/domain/comment/service/CommentWriteService.java
+++ b/src/main/java/com/hanghae/board/domain/comment/service/CommentWriteService.java
@@ -1,0 +1,30 @@
+package com.hanghae.board.domain.comment.service;
+
+import com.hanghae.board.domain.comment.dto.CommentCommand;
+import com.hanghae.board.domain.comment.dto.CommentDto;
+import com.hanghae.board.domain.comment.entity.Comment;
+import com.hanghae.board.domain.comment.mapper.CommentMapper;
+import com.hanghae.board.domain.comment.repository.CommentRepository;
+import com.hanghae.board.security.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentWriteService {
+
+  private final CommentRepository commentRepository;
+  private final CommentMapper commentMapper;
+
+  @Transactional
+  public CommentDto createComment(Long postId, CommentCommand command, UserPrincipal currentUser) {
+    Comment comment = Comment.builder()
+        .content(command.getContent())
+        .postId(postId)
+        .userId(currentUser.getUser().getId())
+        .build();
+
+    return commentMapper.toDto(commentRepository.save(comment));
+  }
+}

--- a/src/main/java/com/hanghae/board/domain/comment/service/CommentWriteService.java
+++ b/src/main/java/com/hanghae/board/domain/comment/service/CommentWriteService.java
@@ -2,9 +2,13 @@ package com.hanghae.board.domain.comment.service;
 
 import com.hanghae.board.domain.comment.dto.CommentCommand;
 import com.hanghae.board.domain.comment.dto.CommentDto;
+import com.hanghae.board.domain.comment.dto.UpdateCommentCommand;
 import com.hanghae.board.domain.comment.entity.Comment;
+import com.hanghae.board.domain.comment.exception.CommentErrorCode;
 import com.hanghae.board.domain.comment.mapper.CommentMapper;
 import com.hanghae.board.domain.comment.repository.CommentRepository;
+import com.hanghae.board.domain.user.dto.UserRole;
+import com.hanghae.board.error.BusinessException;
 import com.hanghae.board.security.UserPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +28,23 @@ public class CommentWriteService {
         .postId(postId)
         .userId(currentUser.getUser().getId())
         .build();
+
+    return commentMapper.toDto(commentRepository.save(comment));
+  }
+
+  @Transactional
+  public CommentDto updateComment(Long commentId, UpdateCommentCommand command,
+      UserPrincipal currentUser) {
+    Comment comment = commentRepository.findWithPessimisticLockById(commentId)
+        .orElseThrow(() -> new BusinessException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+    final boolean isAdmin = currentUser.getUser().getRole().equals(UserRole.ADMIN);
+
+    if (!isAdmin && !comment.getUserId().equals(currentUser.getUser().getId())) {
+      throw new BusinessException(CommentErrorCode.COMMENT_UPDATE_FORBIDDEN);
+    }
+
+    comment.update(command.getContent());
 
     return commentMapper.toDto(commentRepository.save(comment));
   }

--- a/src/main/java/com/hanghae/board/domain/post/service/PostWriteService.java
+++ b/src/main/java/com/hanghae/board/domain/post/service/PostWriteService.java
@@ -23,6 +23,7 @@ public class PostWriteService {
   private final PostRepository postRepository;
   private final PostMapper postMapper;
 
+  @Transactional
   public PostDto createPost(@Valid PostCommand postCommand, UserPrincipal currentUser) {
 
     var post = Post

--- a/src/main/java/com/hanghae/board/domain/user/entity/User.java
+++ b/src/main/java/com/hanghae/board/domain/user/entity/User.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,6 +27,7 @@ public class User {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Positive
   private Long id;
 
   @Column(nullable = false, unique = true, length = 10)

--- a/src/main/java/com/hanghae/board/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/hanghae/board/security/UserDetailsServiceImpl.java
@@ -1,6 +1,5 @@
 package com.hanghae.board.security;
 
-import com.hanghae.board.domain.user.entity.User;
 import com.hanghae.board.domain.user.exception.UserErrorCode;
 import com.hanghae.board.domain.user.repository.UserRepository;
 import com.hanghae.board.error.BusinessException;
@@ -20,10 +19,12 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-    User user = userRepository.findByUsername(username)
-        .orElseThrow(
-            () -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
-    return new UserPrincipal(user);
+    return new UserPrincipal(userRepository.findByUsername(username)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)));
+  }
+  
+  public UserDetails loadUserById(Long id) {
+    return new UserPrincipal(userRepository.findById(id)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND)));
   }
 }

--- a/src/main/java/com/hanghae/board/security/UserPrincipal.java
+++ b/src/main/java/com/hanghae/board/security/UserPrincipal.java
@@ -1,6 +1,7 @@
 package com.hanghae.board.security;
 
 import com.hanghae.board.domain.user.entity.User;
+import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collection;
 import lombok.AllArgsConstructor;
@@ -10,6 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 @AllArgsConstructor
 public class UserPrincipal implements UserDetails {
 
+  @NotNull
   private final User user;
 
   public User getUser() {
@@ -33,6 +35,10 @@ public class UserPrincipal implements UserDetails {
   @Override
   public String getUsername() {
     return user.getUsername();
+  }
+
+  public Long getId() {
+    return user.getId();
   }
 
   @Override

--- a/src/main/java/com/hanghae/board/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/hanghae/board/security/jwt/JwtTokenProvider.java
@@ -1,23 +1,16 @@
 package com.hanghae.board.security.jwt;
 
-import com.hanghae.board.domain.user.dto.UserRole;
-import com.hanghae.board.domain.user.entity.User;
 import com.hanghae.board.security.UserPrincipal;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 import java.util.stream.Collectors;
 import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -29,14 +22,16 @@ public class JwtTokenProvider {
 
   public JwtTokenProvider(
       @Value("${spring.jwt.secret}") String secret,
-      @Value("${spring.jwt.expiration}") long expiration) {
-
+      @Value("${spring.jwt.expiration}") long expiration
+  ) {
     this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
     this.tokenExpirationMilliseconds = expiration * 1000;
     log.info("JwtTokenProvider initialized with expiration: {} seconds", expiration);
   }
 
   public String createToken(Authentication authentication) {
+    UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+
     String authorities = authentication.getAuthorities().stream()
         .map(GrantedAuthority::getAuthority)
         .collect(Collectors.joining(","));
@@ -45,7 +40,7 @@ public class JwtTokenProvider {
     Date expiryDate = new Date(now + this.tokenExpirationMilliseconds);
 
     String token = Jwts.builder()
-        .subject(authentication.getName())
+        .subject(userPrincipal.getId().toString())
         .claim("auth", authorities)
         .issuedAt(new Date(now))
         .expiration(expiryDate)
@@ -54,33 +49,6 @@ public class JwtTokenProvider {
 
     log.debug("Token created for user: {}", authentication.getName());
     return token;
-  }
-
-  public Authentication getAuthentication(String token) {
-    var claims = Jwts.parser()
-        .verifyWith(secretKey)
-        .build()
-        .parseSignedClaims(token)
-        .getPayload();
-
-    Collection<? extends GrantedAuthority> authorities =
-        Arrays.stream(claims.get("auth").toString().split(","))
-            .map(SimpleGrantedAuthority::new)
-            .toList();
-
-    UserRole userRole = UserRole.valueOf(
-        authorities.iterator().next().getAuthority().replace("ROLE_", "")
-    );
-
-    UserDetails principal = new UserPrincipal(
-        User.builder()
-            .username(claims.getSubject())
-            .password("")
-            .role(userRole)
-            .build());
-
-    log.debug("Authentication created for user: {}", claims.getSubject());
-    return new UsernamePasswordAuthenticationToken(principal, token, authorities);
   }
 
   public boolean validateToken(String token) {
@@ -94,14 +62,15 @@ public class JwtTokenProvider {
     }
   }
 
-  public String getUsernameFromToken(String token) {
-    String username = Jwts.parser()
+  public Long getUserIdFromToken(String token) {
+    Long userId = Long.parseLong(Jwts.parser()
         .verifyWith(secretKey)
         .build()
         .parseSignedClaims(token)
         .getPayload()
-        .getSubject();
-    log.debug("Username extracted from token: {}", username);
-    return username;
+        .getSubject());
+
+    log.debug("User ID extracted from token: {}", userId);
+    return userId;
   }
 }

--- a/src/test/java/com/hanghae/board/application/controller/CommentControllerTest.java
+++ b/src/test/java/com/hanghae/board/application/controller/CommentControllerTest.java
@@ -3,12 +3,15 @@ package com.hanghae.board.application.controller;
 
 import static com.hanghae.board.util.FixtureCommon.SUT;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hanghae.board.application.usecase.AddCommentUseCase;
+import com.hanghae.board.application.usecase.UpdateCommentUseCase;
 import com.hanghae.board.config.SecurityConfig;
 import com.hanghae.board.domain.comment.dto.CommentCommand;
+import com.hanghae.board.domain.comment.dto.UpdateCommentCommand;
 import com.hanghae.board.error.GlobalExceptionHandler;
 import com.hanghae.board.security.UserDetailsServiceImpl;
 import com.hanghae.board.security.jwt.JwtTokenProvider;
@@ -33,6 +36,9 @@ class CommentControllerTest {
 
   @MockBean
   private AddCommentUseCase addCommentUseCase;
+
+  @MockBean
+  private UpdateCommentUseCase updateCommentUseCase;
 
   @Autowired
   private ObjectMapper objectMapper;
@@ -59,5 +65,24 @@ class CommentControllerTest {
 
     // then
     result.andExpect(status().isCreated());
+  }
+
+  @Test
+  @WithMockCustomUser(username = "username")
+  void 댓글수정_성공() throws Exception {
+    // given
+    final String url = BASE_URL + "/{commentId}";
+    final Long postId = 1L;
+    final Long commentId = 1L;
+    final UpdateCommentCommand command = SUT.giveMeOne(UpdateCommentCommand.class);
+
+    // when
+    final ResultActions result = mockMvc.perform(put(url, postId, commentId)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(command))
+    );
+
+    // then
+    result.andExpect(status().isOk());
   }
 }

--- a/src/test/java/com/hanghae/board/application/controller/CommentControllerTest.java
+++ b/src/test/java/com/hanghae/board/application/controller/CommentControllerTest.java
@@ -1,0 +1,63 @@
+package com.hanghae.board.application.controller;
+
+
+import static com.hanghae.board.util.FixtureCommon.SUT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hanghae.board.application.usecase.AddCommentUseCase;
+import com.hanghae.board.config.SecurityConfig;
+import com.hanghae.board.domain.comment.dto.CommentCommand;
+import com.hanghae.board.error.GlobalExceptionHandler;
+import com.hanghae.board.security.UserDetailsServiceImpl;
+import com.hanghae.board.security.jwt.JwtTokenProvider;
+import com.hanghae.board.util.WithMockCustomUser;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(CommentController.class)
+@Import({GlobalExceptionHandler.class, SecurityConfig.class})
+class CommentControllerTest {
+
+  private static final String BASE_URL = "/posts/{postId}/comments";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private AddCommentUseCase addCommentUseCase;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @MockBean
+  private JwtTokenProvider jwtTokenProvider;
+
+  @MockBean
+  private UserDetailsServiceImpl userDetailsService;
+
+  @Test
+  @WithMockCustomUser(username = "username")
+  void 댓글작성_성공() throws Exception {
+    // given
+    final String url = BASE_URL;
+    final Long postId = 1L;
+    final CommentCommand command = SUT.giveMeOne(CommentCommand.class);
+
+    // when
+    final ResultActions result = mockMvc.perform(post(url, postId)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(command))
+    );
+
+    // then
+    result.andExpect(status().isCreated());
+  }
+}

--- a/src/test/java/com/hanghae/board/application/controller/PostControllerTest.java
+++ b/src/test/java/com/hanghae/board/application/controller/PostControllerTest.java
@@ -25,6 +25,7 @@ import com.hanghae.board.domain.post.service.PostReadService;
 import com.hanghae.board.domain.post.service.PostWriteService;
 import com.hanghae.board.error.BusinessException;
 import com.hanghae.board.error.GlobalExceptionHandler;
+import com.hanghae.board.security.UserDetailsServiceImpl;
 import com.hanghae.board.security.UserPrincipal;
 import com.hanghae.board.security.jwt.JwtTokenProvider;
 import com.hanghae.board.util.WithMockCustomUser;
@@ -64,6 +65,9 @@ class PostControllerTest {
 
   @MockBean
   private JwtTokenProvider jwtTokenProvider;
+
+  @MockBean
+  private UserDetailsServiceImpl userDetailsService;
 
   @Autowired
   private ObjectMapper objectMapper;

--- a/src/test/java/com/hanghae/board/application/usecase/AddCommentUseCaseTest.java
+++ b/src/test/java/com/hanghae/board/application/usecase/AddCommentUseCaseTest.java
@@ -1,0 +1,121 @@
+package com.hanghae.board.application.usecase;
+
+import static com.hanghae.board.util.FixtureCommon.SUT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+import com.hanghae.board.domain.comment.dto.CommentCommand;
+import com.hanghae.board.domain.comment.dto.CommentDetailDto;
+import com.hanghae.board.domain.comment.dto.CommentDto;
+import com.hanghae.board.domain.comment.dto.UserDto;
+import com.hanghae.board.domain.comment.mapper.CommentMapper;
+import com.hanghae.board.domain.comment.service.CommentWriteService;
+import com.hanghae.board.domain.post.dto.PostDto;
+import com.hanghae.board.domain.post.exception.PostErrorCode;
+import com.hanghae.board.domain.post.service.PostReadService;
+import com.hanghae.board.domain.user.entity.User;
+import com.hanghae.board.domain.user.service.UserReadService;
+import com.hanghae.board.error.BusinessException;
+import com.hanghae.board.security.UserPrincipal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AddCommentUseCaseTest {
+
+  @InjectMocks
+  private AddCommentUseCase target;
+
+  @Mock
+  private CommentWriteService commentWriteService;
+
+  @Mock
+  private PostReadService postReadService;
+
+  @Mock
+  private UserReadService userReadService;
+
+  @Spy
+  private CommentMapper commentMapper = Mappers.getMapper(CommentMapper.class);
+
+
+  @Test
+  void 댓글작성_실패_게시글존재하지않음() {
+    // given
+    final Long postId = 1L;
+    final CommentCommand command = SUT.giveMeOne(CommentCommand.class);
+    final UserPrincipal currentUser = new UserPrincipal(SUT.giveMeOne(User.class));
+    doThrow(new BusinessException(PostErrorCode.POST_NOT_FOUND))
+        .when(postReadService).getPost(postId);
+
+    // when
+    final BusinessException result = assertThrows(BusinessException.class,
+        () -> target.execute(postId, command, currentUser));
+
+    // then
+    assertThat(result.getErrorCode()).isEqualTo(PostErrorCode.POST_NOT_FOUND);
+  }
+
+  @Test
+  void 댓글작성_실패_유저존재하지않음() {
+    // given
+    final CommentCommand command = SUT.giveMeOne(CommentCommand.class);
+    final UserPrincipal currentUser = new UserPrincipal(SUT.giveMeOne(User.class));
+    final PostDto post = SUT.giveMeOne(PostDto.class);
+    doReturn(post).when(postReadService).getPost(post.getId());
+    doThrow(new BusinessException(PostErrorCode.POST_NOT_FOUND))
+        .when(commentWriteService).createComment(post.getId(), command, currentUser);
+
+    // when
+    final BusinessException result = assertThrows(BusinessException.class,
+        () -> target.execute(post.getId(), command, currentUser));
+
+    // then
+    assertThat(result.getErrorCode()).isEqualTo(PostErrorCode.POST_NOT_FOUND);
+  }
+
+  @Test
+  void 댓글작성_성공() {
+    // given
+    final CommentCommand command = SUT.giveMeOne(CommentCommand.class);
+    final User user = SUT.giveMeBuilder(User.class).setNotNull("id").sample();
+    final UserDto userDto = SUT.giveMeBuilder(UserDto.class)
+        .setNotNull("id")
+        .set("username", user.getUsername())
+        .set("role", user.getRole())
+        .sample();
+    final UserPrincipal currentUser = new UserPrincipal(user);
+    final PostDto post = SUT.giveMeOne(PostDto.class);
+    final CommentDto comment = SUT.giveMeBuilder(CommentDto.class)
+        .setNotNull("id")
+        .set("content", command.getContent())
+        .set("postId", post.getId())
+        .set("userId", user.getId())
+        .set("createdAt", LocalDateTime.now())
+        .setNull("updatedAt")
+        .sample();
+    doReturn(post).when(postReadService).getPost(post.getId());
+    doReturn(userDto).when(userReadService).getUser(post.getUserId());
+    doReturn(comment).when(commentWriteService).createComment(post.getId(), command, currentUser);
+
+    // when
+    final CommentDetailDto result = target.execute(post.getId(), command, currentUser);
+
+    // then
+    assertThat(result.getId()).isNotNull();
+    assertThat(result.getContent()).isEqualTo(command.getContent());
+    assertThat(result.getPostId()).isEqualTo(post.getId());
+    assertThat(result.getUserId()).isEqualTo(user.getId());
+    assertThat(result.getCreatedAt()).isNotNull();
+    assertThat(result.getUpdatedAt()).isNull();
+    assertThat(result.getUser()).isNotNull();
+  }
+}

--- a/src/test/java/com/hanghae/board/application/usecase/AddCommentUseCaseTest.java
+++ b/src/test/java/com/hanghae/board/application/usecase/AddCommentUseCaseTest.java
@@ -16,6 +16,7 @@ import com.hanghae.board.domain.post.dto.PostDto;
 import com.hanghae.board.domain.post.exception.PostErrorCode;
 import com.hanghae.board.domain.post.service.PostReadService;
 import com.hanghae.board.domain.user.entity.User;
+import com.hanghae.board.domain.user.exception.UserErrorCode;
 import com.hanghae.board.domain.user.service.UserReadService;
 import com.hanghae.board.error.BusinessException;
 import com.hanghae.board.security.UserPrincipal;
@@ -71,15 +72,15 @@ class AddCommentUseCaseTest {
     final UserPrincipal currentUser = new UserPrincipal(SUT.giveMeOne(User.class));
     final PostDto post = SUT.giveMeOne(PostDto.class);
     doReturn(post).when(postReadService).getPost(post.getId());
-    doThrow(new BusinessException(PostErrorCode.POST_NOT_FOUND))
-        .when(commentWriteService).createComment(post.getId(), command, currentUser);
+    doThrow(new BusinessException(UserErrorCode.USER_NOT_FOUND))
+        .when(userReadService).getUser(post.getUserId());
 
     // when
     final BusinessException result = assertThrows(BusinessException.class,
         () -> target.execute(post.getId(), command, currentUser));
 
     // then
-    assertThat(result.getErrorCode()).isEqualTo(PostErrorCode.POST_NOT_FOUND);
+    assertThat(result.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
   }
 
   @Test

--- a/src/test/java/com/hanghae/board/application/usecase/UpdateCommentUseCaseTest.java
+++ b/src/test/java/com/hanghae/board/application/usecase/UpdateCommentUseCaseTest.java
@@ -1,0 +1,125 @@
+package com.hanghae.board.application.usecase;
+
+import static com.hanghae.board.util.FixtureCommon.SUT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+import com.hanghae.board.domain.comment.dto.CommentDetailDto;
+import com.hanghae.board.domain.comment.dto.CommentDto;
+import com.hanghae.board.domain.comment.dto.UpdateCommentCommand;
+import com.hanghae.board.domain.comment.dto.UserDto;
+import com.hanghae.board.domain.comment.mapper.CommentMapper;
+import com.hanghae.board.domain.comment.service.CommentWriteService;
+import com.hanghae.board.domain.post.dto.PostDto;
+import com.hanghae.board.domain.post.exception.PostErrorCode;
+import com.hanghae.board.domain.post.service.PostReadService;
+import com.hanghae.board.domain.user.entity.User;
+import com.hanghae.board.domain.user.exception.UserErrorCode;
+import com.hanghae.board.domain.user.service.UserReadService;
+import com.hanghae.board.error.BusinessException;
+import com.hanghae.board.security.UserPrincipal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateCommentUseCaseTest {
+
+  @InjectMocks
+  private UpdateCommentUseCase target;
+
+  @Mock
+  private CommentWriteService commentWriteService;
+
+  @Mock
+  private PostReadService postReadService;
+
+  @Mock
+  private UserReadService userReadService;
+
+  @Spy
+  private CommentMapper commentMapper = Mappers.getMapper(CommentMapper.class);
+
+
+  @Test
+  void 댓글수정_실패_게시글존재하지않음() {
+    // given
+    final Long postId = 1L;
+    final Long commentId = 1L;
+    final UpdateCommentCommand command = SUT.giveMeOne(UpdateCommentCommand.class);
+    final UserPrincipal currentUser = new UserPrincipal(SUT.giveMeOne(User.class));
+    doThrow(new BusinessException(PostErrorCode.POST_NOT_FOUND))
+        .when(postReadService).getPost(postId);
+
+    // when
+    final BusinessException result = assertThrows(BusinessException.class,
+        () -> target.execute(postId, commentId, command, currentUser));
+
+    // then
+    assertThat(result.getErrorCode()).isEqualTo(PostErrorCode.POST_NOT_FOUND);
+  }
+
+  @Test
+  void 댓글수정_실패_유저존재하지않음() {
+    // given
+    final Long commentId = 1L;
+    final UpdateCommentCommand command = SUT.giveMeOne(UpdateCommentCommand.class);
+    final UserPrincipal currentUser = new UserPrincipal(SUT.giveMeOne(User.class));
+    final PostDto post = SUT.giveMeOne(PostDto.class);
+    doReturn(post).when(postReadService).getPost(post.getId());
+    doThrow(new BusinessException(UserErrorCode.USER_NOT_FOUND))
+        .when(userReadService).getUser(post.getUserId());
+
+    // when
+    final BusinessException result = assertThrows(BusinessException.class,
+        () -> target.execute(post.getId(), commentId, command, currentUser));
+
+    // then
+    assertThat(result.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+  }
+
+  @Test
+  void 댓글수정_성공() {
+    // given
+    final UpdateCommentCommand command = SUT.giveMeOne(UpdateCommentCommand.class);
+    final User user = SUT.giveMeBuilder(User.class).setNotNull("id").sample();
+    final UserDto userDto = SUT.giveMeBuilder(UserDto.class)
+        .setNotNull("id")
+        .set("username", user.getUsername())
+        .set("role", user.getRole())
+        .sample();
+    final UserPrincipal currentUser = new UserPrincipal(user);
+    final PostDto post = SUT.giveMeOne(PostDto.class);
+    final CommentDto comment = SUT.giveMeBuilder(CommentDto.class)
+        .setNotNull("id")
+        .set("content", command.getContent())
+        .set("postId", post.getId())
+        .set("userId", user.getId())
+        .set("createdAt", LocalDateTime.now())
+        .setNotNull("updatedAt")
+        .sample();
+    doReturn(post).when(postReadService).getPost(post.getId());
+    doReturn(userDto).when(userReadService).getUser(post.getUserId());
+    doReturn(comment).when(commentWriteService)
+        .updateComment(comment.getId(), command, currentUser);
+
+    // when
+    final CommentDetailDto result = target.execute(post.getId(), comment.getId(), command,
+        currentUser);
+
+    // then
+    assertThat(result.getId()).isNotNull();
+    assertThat(result.getContent()).isEqualTo(command.getContent());
+    assertThat(result.getPostId()).isEqualTo(post.getId());
+    assertThat(result.getUserId()).isEqualTo(user.getId());
+    assertThat(result.getCreatedAt()).isNotNull();
+    assertThat(result.getUpdatedAt()).isNotNull();
+  }
+}

--- a/src/test/java/com/hanghae/board/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/hanghae/board/domain/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,36 @@
+package com.hanghae.board.domain.comment.repository;
+
+import static com.hanghae.board.util.FixtureCommon.SUT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hanghae.board.domain.comment.entity.Comment;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class CommentRepositoryTest {
+
+  @Autowired
+  private CommentRepository target;
+
+  @Test
+  void 댓글_작성() {
+    // given
+    final Comment comment = SUT.giveMeBuilder(Comment.class)
+        .setNull("id")
+        .setNull("updatedAt")
+        .sample();
+
+    // when
+    Comment savedComment = target.save(comment);
+
+    // then
+    assertThat(savedComment.getId()).isNotNull();
+    assertThat(savedComment.getPostId()).isEqualTo(comment.getPostId());
+    assertThat(savedComment.getContent()).isEqualTo(comment.getContent());
+    assertThat(savedComment.getCreatedAt()).isNotNull();
+    assertThat(savedComment.getUpdatedAt()).isNull();
+  }
+
+}

--- a/src/test/java/com/hanghae/board/domain/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/hanghae/board/domain/comment/repository/CommentRepositoryTest.java
@@ -33,4 +33,45 @@ class CommentRepositoryTest {
     assertThat(savedComment.getUpdatedAt()).isNull();
   }
 
+  @Test
+  void 댓글_조회() {
+    // given
+    final Comment comment = SUT.giveMeBuilder(Comment.class)
+        .setNull("id")
+        .setNull("updatedAt")
+        .sample();
+    final Comment savedComment = target.save(comment);
+
+    // when
+    final Comment foundComment = target.findById(savedComment.getId()).orElseThrow();
+
+    // then
+    assertThat(foundComment.getId()).isEqualTo(savedComment.getId());
+    assertThat(foundComment.getPostId()).isEqualTo(savedComment.getPostId());
+    assertThat(foundComment.getContent()).isEqualTo(savedComment.getContent());
+    assertThat(foundComment.getCreatedAt()).isEqualTo(savedComment.getCreatedAt());
+    assertThat(foundComment.getUpdatedAt()).isEqualTo(savedComment.getUpdatedAt());
+  }
+
+  @Test
+  void 댓글_조회_쓰기락() {
+    // given
+    final Comment comment = SUT.giveMeBuilder(Comment.class)
+        .setNull("id")
+        .setNull("updatedAt")
+        .sample();
+    final Comment savedComment = target.save(comment);
+
+    // when
+    final Comment foundComment = target.findWithPessimisticLockById(savedComment.getId())
+        .orElseThrow();
+
+    // then
+    assertThat(foundComment.getId()).isEqualTo(savedComment.getId());
+    assertThat(foundComment.getPostId()).isEqualTo(savedComment.getPostId());
+    assertThat(foundComment.getContent()).isEqualTo(savedComment.getContent());
+    assertThat(foundComment.getCreatedAt()).isEqualTo(savedComment.getCreatedAt());
+    assertThat(foundComment.getUpdatedAt()).isEqualTo(savedComment.getUpdatedAt());
+  }
+
 }

--- a/src/test/java/com/hanghae/board/domain/comment/service/CommentWriteServiceTest.java
+++ b/src/test/java/com/hanghae/board/domain/comment/service/CommentWriteServiceTest.java
@@ -1,0 +1,61 @@
+package com.hanghae.board.domain.comment.service;
+
+import static com.hanghae.board.util.FixtureCommon.SUT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+import com.hanghae.board.domain.comment.dto.CommentCommand;
+import com.hanghae.board.domain.comment.dto.CommentDto;
+import com.hanghae.board.domain.comment.entity.Comment;
+import com.hanghae.board.domain.comment.mapper.CommentMapper;
+import com.hanghae.board.domain.comment.repository.CommentRepository;
+import com.hanghae.board.domain.user.entity.User;
+import com.hanghae.board.security.UserPrincipal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommentWriteServiceTest {
+
+  @Spy
+  private final CommentMapper commentMapper = Mappers.getMapper(CommentMapper.class);
+  @InjectMocks
+  private CommentWriteService target;
+  @Mock
+  private CommentRepository commentRepository;
+
+  @Test
+  void 댓글작성_성공() {
+    // given
+    final User user = SUT.giveMeBuilder(User.class)
+        .setNotNull("id")
+        .sample();
+    final UserPrincipal currentUser = new UserPrincipal(user);
+
+    CommentCommand command = SUT.giveMeOne(CommentCommand.class);
+    Comment comment = SUT.giveMeBuilder(Comment.class)
+        .setNotNull("id")
+        .set("content", command.getContent())
+        .set("userId", user.getId())
+        .setNull("updatedAt")
+        .sample();
+    doReturn(comment).when(commentRepository).save(any(Comment.class));
+
+    // when
+    final CommentDto result = target.createComment(comment.getPostId(), command, currentUser);
+
+    // then
+    assertThat(result.getId()).isNotNull();
+    assertThat(result.getContent()).isEqualTo(command.getContent());
+    assertThat(result.getPostId()).isEqualTo(comment.getPostId());
+    assertThat(result.getUserId()).isEqualTo(user.getId());
+    assertThat(result.getCreatedAt()).isNotNull();
+    assertThat(result.getUpdatedAt()).isNull();
+  }
+}

--- a/src/test/java/com/hanghae/board/domain/comment/service/CommentWriteServiceTest.java
+++ b/src/test/java/com/hanghae/board/domain/comment/service/CommentWriteServiceTest.java
@@ -2,16 +2,22 @@ package com.hanghae.board.domain.comment.service;
 
 import static com.hanghae.board.util.FixtureCommon.SUT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 
 import com.hanghae.board.domain.comment.dto.CommentCommand;
 import com.hanghae.board.domain.comment.dto.CommentDto;
+import com.hanghae.board.domain.comment.dto.UpdateCommentCommand;
 import com.hanghae.board.domain.comment.entity.Comment;
+import com.hanghae.board.domain.comment.exception.CommentErrorCode;
 import com.hanghae.board.domain.comment.mapper.CommentMapper;
 import com.hanghae.board.domain.comment.repository.CommentRepository;
+import com.hanghae.board.domain.user.dto.UserRole;
 import com.hanghae.board.domain.user.entity.User;
+import com.hanghae.board.error.BusinessException;
 import com.hanghae.board.security.UserPrincipal;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
@@ -57,5 +63,111 @@ class CommentWriteServiceTest {
     assertThat(result.getUserId()).isEqualTo(user.getId());
     assertThat(result.getCreatedAt()).isNotNull();
     assertThat(result.getUpdatedAt()).isNull();
+  }
+
+  @Test
+  void 댓글수정_실패_존재하지않는댓글() {
+    // given
+    final User user = SUT.giveMeBuilder(User.class)
+        .setNotNull("id")
+        .sample();
+    final UserPrincipal currentUser = new UserPrincipal(user);
+    final Long commentId = 1L;
+    UpdateCommentCommand command = SUT.giveMeOne(UpdateCommentCommand.class);
+    doReturn(Optional.empty()).when(commentRepository).findWithPessimisticLockById(commentId);
+
+    // when
+    final BusinessException exception = assertThrows(BusinessException.class,
+        () -> target.updateComment(commentId, command, currentUser));
+
+    // then
+    assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_NOT_FOUND);
+  }
+
+  @Test
+  void 댓글수정_실패_UserId불일치() {
+    // given
+    final User user = SUT.giveMeBuilder(User.class)
+        .setNotNull("id")
+        .set("role", UserRole.USER)
+        .sample();
+    final UserPrincipal currentUser = new UserPrincipal(user);
+
+    UpdateCommentCommand command = SUT.giveMeOne(UpdateCommentCommand.class);
+    Comment comment = SUT.giveMeBuilder(Comment.class)
+        .setNotNull("id")
+        .setPostCondition("userId", Long.class, userId -> !user.getId().equals(userId))
+        .sample();
+    doReturn(Optional.of(comment)).when(commentRepository)
+        .findWithPessimisticLockById(comment.getId());
+
+    // when
+    final BusinessException exception = assertThrows(BusinessException.class,
+        () -> target.updateComment(comment.getId(), command, currentUser));
+
+    // then
+    assertThat(exception.getErrorCode()).isEqualTo(CommentErrorCode.COMMENT_UPDATE_FORBIDDEN);
+  }
+
+  @Test
+  void 댓글수정_성공() {
+    // given
+    final User user = SUT.giveMeBuilder(User.class)
+        .setNotNull("id")
+        .set("role", UserRole.USER)
+        .sample();
+    final UserPrincipal currentUser = new UserPrincipal(user);
+
+    UpdateCommentCommand command = SUT.giveMeOne(UpdateCommentCommand.class);
+    Comment comment = SUT.giveMeBuilder(Comment.class)
+        .setNotNull("id")
+        .set("userId", user.getId())
+        .setNotNull("updatedAt")
+        .sample();
+    doReturn(Optional.of(comment)).when(commentRepository)
+        .findWithPessimisticLockById(comment.getId());
+    doReturn(comment).when(commentRepository).save(any(Comment.class));
+
+    // when
+    final CommentDto result = target.updateComment(comment.getId(), command, currentUser);
+
+    // then
+    assertThat(result.getId()).isNotNull();
+    assertThat(result.getContent()).isEqualTo(command.getContent());
+    assertThat(result.getPostId()).isEqualTo(comment.getPostId());
+    assertThat(result.getUserId()).isEqualTo(user.getId());
+    assertThat(result.getCreatedAt()).isNotNull();
+    assertThat(result.getUpdatedAt()).isNotNull();
+  }
+
+  @Test
+  void 댓글수정_성공_관리자() {
+    // given
+    final User user = SUT.giveMeBuilder(User.class)
+        .setNotNull("id")
+        .set("role", UserRole.ADMIN)
+        .sample();
+    final UserPrincipal currentUser = new UserPrincipal(user);
+
+    UpdateCommentCommand command = SUT.giveMeOne(UpdateCommentCommand.class);
+    Comment comment = SUT.giveMeBuilder(Comment.class)
+        .setNotNull("id")
+        .setPostCondition("userId", Long.class, userId -> !user.getId().equals(userId))
+        .setNotNull("updatedAt")
+        .sample();
+    doReturn(Optional.of(comment)).when(commentRepository)
+        .findWithPessimisticLockById(comment.getId());
+    doReturn(comment).when(commentRepository).save(any(Comment.class));
+
+    // when
+    final CommentDto result = target.updateComment(comment.getId(), command, currentUser);
+
+    // then
+    assertThat(result.getId()).isNotNull();
+    assertThat(result.getContent()).isEqualTo(command.getContent());
+    assertThat(result.getPostId()).isEqualTo(comment.getPostId());
+    assertThat(result.getUserId()).isEqualTo(comment.getUserId());
+    assertThat(result.getCreatedAt()).isNotNull();
+    assertThat(result.getUpdatedAt()).isNotNull();
   }
 }

--- a/src/test/java/com/hanghae/board/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/hanghae/board/domain/user/repository/UserRepositoryTest.java
@@ -98,6 +98,7 @@ class UserRepositoryTest {
     // given
     AtomicLong counter = new AtomicLong(0);
     final List<User> users = SUT.giveMeBuilder(User.class)
+        .setNull("id")
         .setLazy("username", () -> "username" + counter.getAndIncrement())
         .set("password", "password")
         .sampleList(10);

--- a/src/test/java/com/hanghae/board/security/UserDetailsServiceImplTest.java
+++ b/src/test/java/com/hanghae/board/security/UserDetailsServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.hanghae.board.security;
 
+import static com.hanghae.board.util.FixtureCommon.SUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
@@ -18,7 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @ExtendWith(MockitoExtension.class)
-public class UserDetailsServiceImplTest {
+class UserDetailsServiceImplTest {
 
   @InjectMocks
   private UserDetailsServiceImpl target;
@@ -56,4 +57,34 @@ public class UserDetailsServiceImplTest {
     assertThat(result.getPassword()).isEqualTo("password");
     assertThat(result.getAuthorities()).hasSize(1);
   }
+
+  @Test
+  void 유저로드_실패_By_Id() {
+    // given
+    Long id = 1L;
+    doReturn(Optional.empty()).when(userRepository).findById(id);
+
+    // when
+    final BusinessException result = assertThrows(BusinessException.class,
+        () -> target.loadUserById(id));
+
+    // then
+    assertThat(result.getErrorCode()).isEqualTo(UserErrorCode.USER_NOT_FOUND);
+  }
+
+  @Test
+  void 유저로드_성공_By_Id() {
+    // given
+    User user = SUT.giveMeOne(User.class);
+    doReturn(Optional.of(user)).when(userRepository).findById(user.getId());
+
+    // when
+    final UserDetails result = target.loadUserById(user.getId());
+
+    // then
+    assertThat(result.getUsername()).isEqualTo(user.getUsername());
+    assertThat(result.getPassword()).isEqualTo(user.getPassword());
+    assertThat(result.getAuthorities()).hasSize(1);
+  }
+
 }


### PR DESCRIPTION
추가 요구사항
- 댓글 작성 API
    - 토큰을 검사하여, 유효한 토큰일 경우에만 댓글 작성 가능
    - 선택한 게시글의 DB 저장 유무를 확인하기
    - 선택한 게시글이 있다면 댓글을 등록하고 등록된 댓글 반환하기
- 댓글 수정 API
    - 토큰을 검사한 후, 유효한 토큰이면서 해당 사용자가 작성한 댓글만 수정 가능
    - 선택한 댓글의 DB 저장 유무를 확인하기
    - 선택한 댓글이 있다면 댓글 수정하고 수정된 댓글 반환하기
- 댓글 삭제 API
    - 토큰을 검사한 후, 유효한 토큰이면서 해당 사용자가 작성한 댓글만 삭제 가능
    - 선택한 댓글의 DB 저장 유무를 확인하기
    - 선택한 댓글이 있다면 댓글 삭제하고 Client 로 성공했다는 메시지, 상태코드 반환하기
- 예외 처리
    - 토큰이 필요한 API 요청에서 토큰을 전달하지 않았거나 정상 토큰이 아닐 때는 "토큰이 유효하지 않습니다." 라는 에러메시지와 statusCode: 400을 Client에 반환하기
    - 토큰이 있고, 유효한 토큰이지만 해당 사용자가 작성한 게시글/댓글이 아닌 경우에는 “작성자만 삭제/수정할 수 있습니다.”라는 에러메시지와 statusCode: 400을 Client에 반환하기
    - DB에 이미 존재하는 username으로 회원가입을 요청한 경우 "중복된 username 입니다." 라는 에러메시지와 statusCode: 400을 Client에 반환하기
    - 로그인 시, 전달된 username과 password 중 맞지 않는 정보가 있다면 "회원을 찾을 수 없습니다."라는 에러메시지와 statusCode: 400을 Client에 반환하기